### PR TITLE
Bugfix/break

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -24,7 +24,7 @@ impl Default for Entry {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Status {
     Connect,
     Disconnect,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -23,7 +23,7 @@ pub struct Settings {
     pub workperday: WorkPerDay,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
 #[allow(unused)]
 pub struct BreakLimit {
     pub start: u8,

--- a/src/status_daily.rs
+++ b/src/status_daily.rs
@@ -1569,12 +1569,12 @@ mod tests {
                     Entry {
                         id: 1,
                         status: Status::Connect,
-                        time: Local.ymd(2022, 4, 2).and_hms(8, 0, 0),
+                        time: Local.ymd(2022, 2, 4).and_hms(8, 0, 0),
                     },
                     Entry {
                         id: 2,
                         status: Status::End,
-                        time: Local.ymd(2022, 4, 2).and_hms(14, 0, 0),
+                        time: Local.ymd(2022, 2,4).and_hms(14, 0, 0),
                     },
                 ]
                 .to_vec(),

--- a/src/status_weekly.rs
+++ b/src/status_weekly.rs
@@ -386,9 +386,9 @@ mod tests {
             log::debug!("{}", s);
 
             let week = 10;
-            let total = StatusTime::from(Duration::hours(36).add(Duration::minutes(47)));
-            let overtime = StatusTime::from(Duration::minutes(-193));
-            let decimal = 36.78333333333333;
+            let total = StatusTime::from(Duration::hours(36).add(Duration::minutes(32)));
+            let overtime = StatusTime::from(Duration::hours(-3).add(Duration::minutes(-28)));
+            let decimal = 36.53333333333333;
 
             assert_eq!(week, s.week, "number of week");
             assert_eq!(total, s.total, "total calculation");


### PR DESCRIPTION
Fixes bug:

- show end status without any break taken
- assert break, which is run before invoking end, fills up remaining required break before end entry